### PR TITLE
Fix the problem of not being able to provide files when using `render: shell`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -34,7 +34,6 @@ body:
         Ideally, the entire output of the engine should be zipped up and attached to provide the most information possible.
 
         Keep in mind that users are not in a position to decide which files will contribute to debugging the problem, unless they are familiar with the source code and behavior. When in doubt, include as many relevant files as possible.
-      render: Shell
       placeholder: |
         Engine.log.zip (Highly recommended)
 


### PR DESCRIPTION
This is due to my checking error.
My apologies.

## Expected
- We expect the following button to appear as `Provide Instructions on Reproducing the Problem`.

![image](https://github.com/Monitor144hz/Pandora-Behaviour-Engine-Plus/assets/68905624/ac120bd8-56dd-4e8c-8862-53a0c16c24ba)

## Acutual
- But in the case of the `Provide Relevant Files` item with `placeholder`, the buttons do not appear for some reason. 
   (Drag and drop doesn't work either. And **this means we cannot provide the files.**)

![image](https://github.com/Monitor144hz/Pandora-Behaviour-Engine-Plus/assets/68905624/b9a79cb4-8666-4e66-b378-fedadc356714)

Here is the URL I tried (Clicking on the `Provide Relevant Files` textarea in this URL reproduces the problem).
- [forked repo's issue edit page](https://github.com/SARDONYX-forks/Pandora-Behaviour-Engine-Plus/issues/new?assignees=&labels=bug&projects=&template=bug-report.yaml&title=%5BBug%5D%3A+)

But I am using `placeholder` in my project and the button appears fine.
- [My project's bug-report.yaml](https://github.com/SARDONYX-sard/dar-to-oar/blob/main/.github/ISSUE_TEMPLATE/bug-report.yaml?plain=1#L41)
- [My project's bug-report](https://github.com/SARDONYX-sard/dar-to-oar/issues/new?assignees=&labels=bug&projects=&template=bug-report.yaml&title=%5BBug%5D%3A+)

ps: I found probably the cause.
I use `render: shell` at the end of my issue template and the button does not appear as well. (Json schema says it does syntax highlighting, but it seems to do other things as well.)