### PR TITLE
chore(github-template): add `feature-request.yaml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,17 @@
+name: Feature Request
+description: File a feature request
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Could you please tell us about the behavior you expect?
+
+  - type: textarea
+    id: other
+    attributes:
+      label: other
+      description: About everything else.


### PR DESCRIPTION
I provide a template that I often use.

## Reason for not adding `require: true` to the `Expected behavior` field
Because the title itself may describe the expected behavior.

If we made this field mandatory, the same content would be written in both the title and the message. (This field could be replaced with `please give me more details`, etc.)