### PR TITLE
chore(bug-report): add a checkbox for duplicate confirmation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -5,6 +5,14 @@ title: "[Bug]: "
 labels: ["bug"]
 
 body:
+  - type: checkboxes
+    id: no-duplicate-feature
+    attributes:
+      label: Check for duplicate issues
+      options:
+        - label: I have verified that there are no duplicate [issues](https://github.com/Monitor144hz/Pandora-Behaviour-Engine-Plus/issues).
+          required: true
+
   - type: input
     id: version
     attributes:


### PR DESCRIPTION
## Objective
To reduce the burden on the maintainer by allowing bug reporters to check for duplicate issues in advance.