### PR TITLE
[Refactor]: Migrate to System.CommandLine for argument parsing

### DIFF
--- a/Pandora Behaviour Engine/Models/BehaviourEngine.cs
+++ b/Pandora Behaviour Engine/Models/BehaviourEngine.cs
@@ -4,6 +4,7 @@ using Pandora.API.Patch.Engine.Config;
 using Pandora.Models.Patch.Configs;
 using Pandora.Models.Patch.Engine.Plugins;
 using Pandora.Models.Patch.Plugins;
+using Pandora.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -96,16 +97,12 @@ public class BehaviourEngine
 				}
 			}
 		}
-		var args = Environment.GetCommandLineArgs();
-		var inputArg = args.Where(s => s.StartsWith("-tesv:", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+		var rawArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+		var options = LaunchOptions.Parse(rawArgs);
 
-		if (inputArg != null)
+		if (options.SkyrimGameDirectory is not null)
 		{
-			var argArr = inputArg.AsSpan();
-			var pathArr = argArr.Slice(6);
-			var path = pathArr.Trim().ToString();
-
-			SkyrimGameDirectory = new DirectoryInfo(Path.Join(path, "Data"));
+			SkyrimGameDirectory = new DirectoryInfo(Path.Join(options.SkyrimGameDirectory.FullName, "Data"));
 		}
 	}
 

--- a/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
+++ b/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
@@ -15,6 +15,7 @@
     <VersionSuffix>beta</VersionSuffix>
     <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
     <CETCompat>false</CETCompat>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.0.10" />
     <PackageReference Include="DynamicData" Version="9.4.1" />
     <PackageReference Include="FluentAvaloniaUI" Version="2.3.0" />

--- a/Pandora Behaviour Engine/Utils/LaunchOptions.cs
+++ b/Pandora Behaviour Engine/Utils/LaunchOptions.cs
@@ -1,0 +1,61 @@
+﻿using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.IO;
+
+namespace Pandora.Utils;
+
+public class LaunchOptions
+{
+	public DirectoryInfo? OutputDirectory { get; private set; }
+	public DirectoryInfo? SkyrimGameDirectory { get; private set; }
+	public bool AutoRun { get; private set; }
+	public bool AutoClose { get; private set; }
+	public bool UseSkyrimDebug64 { get; private set; }
+
+	public static LaunchOptions Parse(string[] args)
+	{
+		var options = new LaunchOptions();
+
+		var outputOption = new Option<DirectoryInfo?>(
+			aliases: ["--output", "-o"],
+			description: "Output directory");
+
+		var tesvOption = new Option<DirectoryInfo?>(
+			"--tesv",
+			description: "Skyrim directory (TESV), should point to Skyrim root folder");
+
+		var autoRunOption = new Option<bool>(
+			"--auto_run",
+			description: "Automatically run after start");
+
+		var autoCloseOption = new Option<bool>(
+			"--auto_close",
+			description: "Close app after execution");
+
+		var skyrimDebug64Option = new Option<bool>(
+			"--skyrim_debug64",
+			description: "Close app after execution");
+
+		var rootCommand = new RootCommand
+		{
+			outputOption,
+			tesvOption,
+			autoRunOption,
+			autoCloseOption,
+			skyrimDebug64Option
+		};
+
+		rootCommand.SetHandler((DirectoryInfo? output, DirectoryInfo? tesv, bool autorun, bool autoclose, bool useskyrimdebug64) =>
+		{
+			options.OutputDirectory = output;
+			options.AutoRun = autorun;
+			options.AutoClose = autoclose;
+			options.SkyrimGameDirectory = tesv;
+			options.UseSkyrimDebug64 = useskyrimdebug64;
+		}, outputOption, tesvOption, autoRunOption, autoCloseOption, skyrimDebug64Option);
+
+		rootCommand.Invoke(args);
+
+		return options;
+	}
+}


### PR DESCRIPTION
This PR updates the parsing of command line arguments and uses the new argument style:
`--output or -o`
`--auto_run`
`--auto_close`
`--skyrim_debug64`
`--tesv`

_Now it doesn't matter how many spaces you have after arguments_

Resolves #448 