### PR TITLE
[Fix]: Return autoscroll to end in LogText

### DIFF
--- a/Pandora Behaviour Engine/View/Controls/LogBox.axaml
+++ b/Pandora Behaviour Engine/View/Controls/LogBox.axaml
@@ -13,7 +13,8 @@
              FontFamily="Consolas"
              FontSize="13"
              Text="{Binding LogText}"
-             TextWrapping="WrapWithOverflow" />
+             TextWrapping="WrapWithOverflow"
+             TextChanged="TextBox_TextChanged" />
     <Border Background="Transparent" ToolTip.Tip="Preloading..." ToolTip.Placement="Bottom" Width="24" Height="24" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8" >
       <ui:ProgressRing IsActive="{Binding IsPreloading}" IsEnabled="{Binding IsPreloading}" />
     </Border>

--- a/Pandora Behaviour Engine/View/Controls/LogBox.axaml.cs
+++ b/Pandora Behaviour Engine/View/Controls/LogBox.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.ReactiveUI;
 using Pandora.ViewModels;
 
@@ -9,4 +10,7 @@ public partial class LogBox : ReactiveUserControl<EngineViewModel>
     {
         InitializeComponent();
     }
+
+	private void TextBox_TextChanged(object sender, TextChangedEventArgs e) => 
+		LogTextBox.CaretIndex = int.MaxValue;
 }


### PR DESCRIPTION
This PR brings back autoscroll to the end in LogText