### PR TITLE
[Update]: More info if output folder is not set

### DIFF
--- a/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
+++ b/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
@@ -35,6 +35,7 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.Management" Version="9.0.6" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.0.10" />
     <PackageReference Include="DynamicData" Version="9.4.1" />
     <PackageReference Include="FluentAvaloniaUI" Version="2.3.0" />

--- a/Pandora Behaviour Engine/Utils/ProcessUtils.cs
+++ b/Pandora Behaviour Engine/Utils/ProcessUtils.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Pandora.Utils;
+
+public static class ProcessUtils
+{
+	public static bool IsLaunchedFromModOrganizer()
+	{
+		try
+		{
+			using var process = Process.GetCurrentProcess();
+			int parentPid = GetParentProcessId(process.Id);
+			if (parentPid == 0) return false;
+
+			using var parent = Process.GetProcessById(parentPid);
+			var parentName = parent.ProcessName.ToLowerInvariant();
+
+			if (parentName.Contains("modorganizer") || parentName.Contains("mo2"))
+				return true;
+
+			if (parentName.Contains("wine"))
+				return TryDetectModOrganizerViaWine(parentPid);
+
+			return false;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private static int GetParentProcessId(int pid)
+	{
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			using var searcher = new System.Management.ManagementObjectSearcher(
+				$"SELECT ParentProcessId FROM Win32_Process WHERE ProcessId = {pid}");
+
+			foreach (var obj in searcher.Get())
+			{
+				return Convert.ToInt32(obj["ParentProcessId"]);
+			}
+		}
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			var statusPath = $"/proc/{pid}/status";
+			if (File.Exists(statusPath))
+			{
+				var lines = File.ReadAllLines(statusPath);
+				var ppidLine = lines.FirstOrDefault(l => l.StartsWith("PPid:"));
+				if (ppidLine != null && int.TryParse(ppidLine.Split(':')[1].Trim(), out int ppid))
+				{
+					return ppid;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	private static bool TryDetectModOrganizerViaWine(int winePid)
+	{
+		try
+		{
+			string cmdlinePath = $"/proc/{winePid}/cmdline";
+			if (File.Exists(cmdlinePath))
+			{
+				var cmdline = File.ReadAllText(cmdlinePath).ToLowerInvariant();
+				return cmdline.Contains("modorganizer") || cmdline.Contains("mo2");
+			}
+		}
+		catch { }
+
+		return false;
+	}
+}

--- a/Pandora Behaviour Engine/View/EngineView.axaml
+++ b/Pandora Behaviour Engine/View/EngineView.axaml
@@ -22,9 +22,9 @@
     <vws:PatchBox Grid.Row="1" Margin="0 6 0 0" />
     <GridSplitter Grid.Row="2" Classes="innerStyle" CornerRadius="6" ResizeDirection="Rows" Width="90" />
     <vws:LogBox Grid.Row="3" Margin="0 0 0 10" />
-    <ui:InfoBar Grid.Row="4" Severity="Informational" Title="Info" Message="Output folder not set via command line arguments -o '{path}'. Files will be generated in the:" IsOpen="{Binding !IsOutputFolderCustomSet}" IsVisible="{Binding $self.IsOpen}" Margin="0 0 0 10">
+    <ui:InfoBar Grid.Row="4" Severity="Informational" Title="Info" Message="{Binding OutputDirectoryMessage}" IsOpen="{Binding !IsOutputFolderCustomSet}" IsVisible="{Binding $self.IsOpen}" Margin="0 0 0 10">
       <ui:InfoBar.ActionButton>
-        <HyperlinkButton Content="{Binding CurrentDirectoryInfo}" NavigateUri="{Binding CurrentDirectoryInfo}" />
+        <HyperlinkButton Content="here" NavigateUri="{Binding CurrentDirectoryInfo}" IsVisible="{Binding !IsVisibleLinkOutputDirectory}" />
       </ui:InfoBar.ActionButton>
     </ui:InfoBar>
     <vws:LaunchElement Grid.Row="5" />

--- a/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
+++ b/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
@@ -48,8 +48,10 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 
 	[Reactive] private bool _isPreloading;
 	[Reactive] private bool _isOutputFolderCustomSet;
+	[Reactive] private bool _isVisibleLinkOutputDirectory;
 	[Reactive] private string _logText = string.Empty;
 	[Reactive] private string _searchTerm = string.Empty;
+	[Reactive] private string _outputDirectoryMessage = string.Empty;
 
 	[ObservableAsProperty(ReadOnly = false)] private bool? _allSelected;
 	[ObservableAsProperty(ReadOnly = false)] private bool _engineRunning;
@@ -112,6 +114,15 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 		{
 			currentDirectory = options.OutputDirectory;
 			IsOutputFolderCustomSet = true;
+		}
+		else
+		{
+			bool fromMO2 = ProcessUtils.IsLaunchedFromModOrganizer();
+
+			IsVisibleLinkOutputDirectory = fromMO2;
+			OutputDirectoryMessage = fromMO2
+				? "Output folder not set via command line arguments (-o). If you use configured output folder via MO2 (Create files in mod ...), then ignore this."
+				: "Output folder is not set. Set it either via argument (-o). While the files will be generated in:";
 		}
 
 		autoRun = options.AutoRun;


### PR DESCRIPTION
This PR adds more information if the output folder is not set via command line arguments. Depending on whether you run Pandora via MO2 or not, the application reports that the output folder is not set.