### PR TITLE
[Refactor(cli)]: Migrate to new System.CommandLine API

### DIFF
--- a/Pandora Behaviour Engine/App.axaml.cs
+++ b/Pandora Behaviour Engine/App.axaml.cs
@@ -28,7 +28,7 @@ public partial class App : Application
 
 		if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
 		{
-			LaunchOptions.Current = LaunchOptions.Parse(desktop.Args);
+			LaunchOptions.Current = LaunchOptions.Parse(desktop.Args, caseInsensitive: true);
 			SetupNLogConfigForSingleFilePublish();
 			// Line below is needed to remove Avalonia data validation.
 			// Without this line you will get duplicate validations from both Avalonia and CT

--- a/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
+++ b/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
@@ -34,7 +34,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta6.25358.103" />
     <PackageReference Include="System.Management" Version="9.0.6" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.2" />
     <PackageReference Include="DynamicData" Version="9.4.1" />


### PR DESCRIPTION
This PR updates System.CommandLine to the latest version (2.0.0-beta6), which has had key API changes since version 2.0.0-beta5. The argument parsing code has been updated to match the new API. The method that normalizes the arguments read in a case-insensitive manner has also been updated.

Read more about the API changes: https://learn.microsoft.com/en-us/dotnet/standard/commandline/migration-guide-2.0.0-beta5