### PR TITLE
[Feat(ui)]: Display color border window when patch process is running

### DIFF
--- a/Pandora Behaviour Engine/Utils/Platform/Windows/FlashWindowEx.cs
+++ b/Pandora Behaviour Engine/Utils/Platform/Windows/FlashWindowEx.cs
@@ -8,7 +8,7 @@ public static partial class TaskbarFlasher
 {
 	private static nint? _lastFlashingHandle;
 
-	public static void FlashUntilFocused(Window window)
+	public static void FlashUntilFocused(this Window window)
 	{
 		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			return;
@@ -34,7 +34,7 @@ public static partial class TaskbarFlasher
 		window.Activated += OnWindowActivated;
 	}
 
-	public static void StopFlashing(Window window)
+	public static void StopFlashing(this Window window)
 	{
 		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			return;
@@ -61,15 +61,13 @@ public static partial class TaskbarFlasher
 	{
 		if (sender is Window window)
 		{
-			StopFlashing(window);
+			window.StopFlashing();
 			window.Activated -= OnWindowActivated;
 		}
 	}
 
-	private static nint GetWindowHandle(Window window)
-	{
-		return window.TryGetPlatformHandle()?.Handle ?? nint.Zero;
-	}
+	private static nint GetWindowHandle(Window window) =>
+		window.TryGetPlatformHandle()?.Handle ?? nint.Zero;
 
 	#region WinAPI
 

--- a/Pandora Behaviour Engine/Utils/Platform/Windows/WindowVisualState.cs
+++ b/Pandora Behaviour Engine/Utils/Platform/Windows/WindowVisualState.cs
@@ -1,0 +1,9 @@
+﻿namespace Pandora.Utils;
+
+public enum WindowVisualState
+{
+	Idle,
+	Running,
+	Error,
+	Indeterminate
+}

--- a/Pandora Behaviour Engine/Utils/Platform/Windows/WindowsPlatformHelper.cs
+++ b/Pandora Behaviour Engine/Utils/Platform/Windows/WindowsPlatformHelper.cs
@@ -1,0 +1,38 @@
+﻿using Avalonia.Media;
+using FluentAvalonia.UI.Windowing;
+using System;
+
+namespace Pandora.Utils.Platform.Windows;
+
+public static class WindowsPlatformHelper
+{
+	private static readonly Color DefaultBorderColor = Color.Parse("#FF9370DB");
+	private static readonly Color RunningBorderColor = Color.Parse("#FFFF614D");
+
+	public static void SetVisualWindowState(AppWindow window, WindowVisualState state)
+	{
+		if (!OperatingSystem.IsWindows())
+			return;
+
+		switch (state)
+		{
+			case WindowVisualState.Idle:
+				window.PlatformFeatures.SetWindowBorderColor(DefaultBorderColor);
+				window.PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.None);
+				break;
+
+			case WindowVisualState.Running:
+				window.PlatformFeatures.SetWindowBorderColor(RunningBorderColor);
+				window.PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.Indeterminate);
+				break;
+
+			case WindowVisualState.Indeterminate:
+				window.PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.Indeterminate);
+				break;
+
+			case WindowVisualState.Error:
+				window.PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.Error);
+				break;
+		}
+	}
+}

--- a/Pandora Behaviour Engine/View/MainWindow.axaml.cs
+++ b/Pandora Behaviour Engine/View/MainWindow.axaml.cs
@@ -1,5 +1,6 @@
-using Avalonia.Media;
 using FluentAvalonia.UI.Windowing;
+using Pandora.Utils;
+using Pandora.Utils.Platform.Windows;
 using System;
 
 namespace Pandora.Views;
@@ -10,45 +11,37 @@ public partial class MainWindow : AppWindow
 	{
 		InitializeComponent();
 
-		if (IsWindows)
-		{
-			Color color = Color.Parse("#FF9370DB");
-			PlatformFeatures.SetWindowBorderColor(color);
-		}
+		SetVisualState(WindowVisualState.Idle);
 
-		TitleBar.ExtendsContentIntoTitleBar = true;
-		TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
-		TitleBar.Height = 42;
+		ConfigureTitleBar();
+		RestoreWindowSize();
 
-		var savedWindowHeight = Properties.GUISettings.Default.WindowHeight;
-		var savedWindowWidth = Properties.GUISettings.Default.WindowWidth;
-		Height = savedWindowHeight > 1 ? savedWindowHeight : Height;
-		Width = savedWindowWidth > 1 ? savedWindowWidth : Width;
 		Closed += MainWindow_Closed;
 	}
+
 	private void MainWindow_Closed(object? sender, EventArgs e)
 	{
 		Properties.GUISettings.Default.WindowHeight = Height;
 		Properties.GUISettings.Default.WindowWidth = Width;
 		Properties.GUISettings.Default.Save();
 	}
-	public void SetTaskbarProgress(bool isRunning)
+	private void ConfigureTitleBar()
 	{
-		if (!IsWindows) return;
-
-		if (isRunning)
-		{
-			PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.Indeterminate);
-		}
-		else
-		{
-			PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.None);
-		}
+		TitleBar.ExtendsContentIntoTitleBar = true;
+		TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
+		TitleBar.Height = 42;
 	}
-	public void SetTaskbarProgressError()
+	private void RestoreWindowSize()
 	{
-		if (!IsWindows) return;
-		PlatformFeatures.SetTaskBarProgressBarState(TaskBarProgressBarState.Error);
+		var savedHeight = Properties.GUISettings.Default.WindowHeight;
+		var savedWidth = Properties.GUISettings.Default.WindowWidth;
+
+		if (savedHeight > 100)
+			Height = savedHeight;
+
+		if (savedWidth > 100)
+			Width = savedWidth;
 	}
 
+	public void SetVisualState(WindowVisualState state) => WindowsPlatformHelper.SetVisualWindowState(this, state);
 }

--- a/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
+++ b/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
@@ -231,10 +231,8 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 	{
 		if (success)
 		{
-			mainWindow?.SetTaskbarProgress(false);
-
-			if (mainWindow is not null && !mainWindow.IsActive)
-				TaskbarFlasher.FlashUntilFocused(mainWindow);
+			mainWindow?.SetVisualState(WindowVisualState.Idle);
+			mainWindow?.FlashUntilFocused();
 
 			await JsonModSettingsStore.SaveAsync(SourceMods, PandoraPaths.ActiveModsFile.FullName);
 
@@ -243,7 +241,7 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 		}
 		else
 		{
-			mainWindow?.SetTaskbarProgressError();
+			mainWindow?.SetVisualState(WindowVisualState.Error);
 			EngineLoggerAdapter.AppendLine("Launch aborted. Existing output was not cleared, and current patch list will not be saved.");
 		}
 	}
@@ -252,7 +250,7 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 	private async Task LaunchEngine()
 	{
 		var mainWindow = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow as MainWindow;
-		mainWindow?.SetTaskbarProgress(true);
+		mainWindow?.SetVisualState(WindowVisualState.Running);
 
 		try
 		{
@@ -271,7 +269,7 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 		}
 		finally
 		{
-			mainWindow?.SetTaskbarProgress(false);
+			mainWindow?.SetVisualState(WindowVisualState.Idle);
 		}
 	}
 


### PR DESCRIPTION
This PR adds a colored border when the patcher is running that changes to a red-orange color. This helps to visually display the state of the patcher in addition to the existing loading ring.

If you think this change is unnecessary, then you can safely reject it, perhaps you have different tastes in the design of the application 😊
If you like this change but you don't like the color, then we can make it configurable

<img width="991" height="992" alt="image" src="https://github.com/user-attachments/assets/84ac98e1-c14f-46be-83d6-f910913380d6" />
