### PR TITLE
[Fix(test)]: Incorrect file output in EndToEnd test

### DIFF
--- a/Pandora Tests/Resources.cs
+++ b/Pandora Tests/Resources.cs
@@ -6,7 +6,7 @@ public static class Resources
 {
 	public static readonly DirectoryInfo TemplateDirectory = new(Path.Combine(Environment.CurrentDirectory, "Pandora_Engine", "Skyrim", "Template"));
 	public static readonly DirectoryInfo OutputDirectory = new(Path.Combine(Environment.CurrentDirectory, "Output"));
-	public static readonly DirectoryInfo CurrentDirectory = new DirectoryInfo(Environment.CurrentDirectory);
+	public static readonly DirectoryInfo CurrentDirectory = new(Environment.CurrentDirectory);
 
 	static Resources()
 	{


### PR DESCRIPTION
This PR fixes a test where `SetOutputPath()` was set before the engine configuration was set. This resulted in the wrong output directory.
Also brings improvements like:
- adding a check for the meshes folder with generated `.hkx` files
- adding a check for the presence of an exporter
- adding more logs to control and track where the files are generated