### PR TITLE
[Fix]: Not working option --skyrim_debug64

### DIFF
--- a/Pandora Behaviour Engine/Services/EngineConfigurationService.cs
+++ b/Pandora Behaviour Engine/Services/EngineConfigurationService.cs
@@ -21,28 +21,29 @@ public class EngineConfigurationService
 
 	public void SetCurrentFactory(IEngineConfigurationFactory factory) => _currentFactory = factory;
 
-	public IReadOnlyCollection<IEngineConfigurationViewModel> GetInitialConfigurations(ReactiveCommand<IEngineConfigurationFactory, Unit> setCommand)
+	public void Initialize(bool useSkyrimDebug64, ReactiveCommand<IEngineConfigurationFactory, Unit> setCommand)
 	{
-		_configurations.Clear();
+		if (useSkyrimDebug64)
+			_currentFactory = new ConstEngineConfigurationFactory<SkyrimDebugConfiguration>("Debug");
 
+		_configurations.Clear();
 		var root = new EngineConfigurationViewModelContainer("Skyrim 64",
 			new EngineConfigurationViewModelContainer("Behavior",
 				new EngineConfigurationViewModelContainer("Patch",
-					new EngineConfigurationViewModel(_currentFactory, setCommand),
+					new EngineConfigurationViewModel(new ConstEngineConfigurationFactory<SkyrimConfiguration>("Normal"), setCommand),
 					new EngineConfigurationViewModel(new ConstEngineConfigurationFactory<SkyrimDebugConfiguration>("Debug"), setCommand)
 				)
 			)
 		);
-
 		_configurations.Add(root);
 
 		foreach (var plugin in BehaviourEngine.EngineConfigurations)
 		{
 			RegisterPlugin(plugin, setCommand);
 		}
-
-		return _configurations;
 	}
+
+	public IReadOnlyCollection<IEngineConfigurationViewModel> GetConfigurations() => _configurations;
 
 	private void RegisterPlugin(IEngineConfigurationPlugin plugin, ReactiveCommand<IEngineConfigurationFactory, Unit> setCommand)
 	{

--- a/Pandora Behaviour Engine/Services/StartupService.cs
+++ b/Pandora Behaviour Engine/Services/StartupService.cs
@@ -8,10 +8,11 @@ namespace Pandora.Services;
 
 public class StartupService
 {
-	public record StartupInfo(bool IsCustomSet, bool AutoRun, bool AutoClose, string Message);
+	public record StartupInfo(bool IsCustomSet, bool AutoRun, bool AutoClose, string Message, bool UseSkyrimDebug64);
 
 	public static StartupInfo Handle(LaunchOptions? options)
 	{
+		bool useSkyrimDebug64 = options.UseSkyrimDebug64;
 		var outputDir = options?.OutputDirectory;
 		var modManager = ProcessUtils.Source;
 
@@ -27,7 +28,7 @@ public class StartupService
 			};
 		}
 
-		return new StartupInfo(isCustom, options?.AutoRun ?? false, options?.AutoClose ?? false, message);
+		return new StartupInfo(isCustom, options?.AutoRun ?? false, options?.AutoClose ?? false, message, useSkyrimDebug64);
 	}
 
 	public static void LogPlugins()

--- a/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
+++ b/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
@@ -75,8 +75,10 @@ public partial class EngineViewModel : ViewModelBase, IActivatableViewModel
 		_isOutputFolderCustomSet = startup.IsCustomSet;
 		_outputDirectoryMessage = startup.Message;
 
+		_configService.Initialize(startup.UseSkyrimDebug64, SetEngineConfigCommand);
+
 		EngineConfigurationViewModels = new ObservableCollection<IEngineConfigurationViewModel>(
-			_configService.GetInitialConfigurations(SetEngineConfigCommand));
+			_configService.GetConfigurations());
 
 		SourceMods.ToObservableChangeSet()
 			.AutoRefresh(x => x.Priority)


### PR DESCRIPTION
This PR returns the forgotten logic of setting the Debug configuration when the `--skyrim_debug64` option is set when starting the application