### PR TITLE
[Refactor(test)]: Use ITestOutputHelper instead NLog in EndToEnd test

### DIFF
--- a/Pandora Tests/EndToEndTests.cs
+++ b/Pandora Tests/EndToEndTests.cs
@@ -1,5 +1,4 @@
-﻿using NLog;
-using Pandora.API.Patch.IOManagers;
+﻿using Pandora.API.Patch.IOManagers;
 using Pandora.Data;
 using Pandora.Models;
 using Pandora.Models.Patch.Configs;


### PR DESCRIPTION
Replaced NLog logger with standard output ITestOutputHelper XUnit.