### PR TITLE
[Chore]: Checkout actual branch in license header fix workflow

### DIFF
--- a/.github/workflows/license-header-fix.yaml
+++ b/.github/workflows/license-header-fix.yaml
@@ -10,8 +10,10 @@ jobs:
   fix-license-headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - name: fix headers
         uses: apache/skywalking-eyes/header@v0.7.0
         with:


### PR DESCRIPTION
This should hopefully fix failures in workflow runs where commits need to be added because of missing license headers (like [this one](https://github.com/Monitor221hz/Pandora-Behaviour-Engine-Plus/actions/runs/17179541361/job/48740119370)). Commits can't be added in a detached state.