### PR TITLE
[Test]: Add dedicated test class for Skyrim path resolution priorities

### DIFF
--- a/Pandora Tests/SkyrimPathResolverPriorityTests.cs
+++ b/Pandora Tests/SkyrimPathResolverPriorityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Win32;
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2025 Pandora Behaviour Engine Contributors
+
+using Microsoft.Win32;
 using Pandora.Utils;
 
 namespace PandoraTests;


### PR DESCRIPTION
This PR introduces a new dedicated test class SkyrimPathResolverPriorityTests, which covers resolution priority logic for Skyrim installation paths.

The new tests ensure that `SkyrimPathResolver.Resolve()` behaves correctly under different conditions:

- Priority 1 – command line arguments (--tesv) are used when provided.
- Priority 2 – current working directory is used as Start In when valid.
- Priority 3 – registry path is used if args and current dir are invalid.
- Fallback – current directory is returned when no valid path is found.

These tests improve confidence in the resolver logic by simulating real-world scenarios with valid, invalid, and conflicting paths.