### PR TITLE
[Chore]: Set logger config in build

### DIFF
--- a/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
+++ b/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
@@ -104,14 +104,6 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
-    <None Update="NLog.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </None>
-    <None Update="*.log">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </None>
     <!--<None Update="Plugins\Test Plugin\plugin.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
This PR removes the generation of `NLog.config` outside the build and does it inline. For a release, there is no point in having this configuration outside the build, since it will not produce any more logs.