### PR TITLE
[Fix]: An exception occurs if the file PreviousOutptut.txt does not exist

### DIFF
--- a/Pandora Behaviour Engine/Models/Patch.IO/Skyrim64/DebugPackFileExporter.cs
+++ b/Pandora Behaviour Engine/Models/Patch.IO/Skyrim64/DebugPackFileExporter.cs
@@ -85,6 +85,8 @@ public class DebugPackFileExporter : IMetaDataExporter<PackFile>
 
 	public void SaveMetaData(IEnumerable<PackFile> packFiles)
 	{
+		PreviousOutputFile.Directory?.Create();
+
 		using (FileStream readStream = PreviousOutputFile.Create())
 		{
 			using (StreamWriter writer = new(readStream))

--- a/Pandora Behaviour Engine/Models/Patch.IO/Skyrim64/PackFileExporter.cs
+++ b/Pandora Behaviour Engine/Models/Patch.IO/Skyrim64/PackFileExporter.cs
@@ -101,6 +101,8 @@ public class PackFileExporter : IMetaDataExporter<PackFile>
 
 	public void SaveMetaData(IEnumerable<PackFile> packFiles)
 	{
+		PreviousOutputFile.Directory?.Create();
+
 		using (FileStream readStream = PreviousOutputFile.Create())
 		{
 			using (StreamWriter writer = new(readStream))


### PR DESCRIPTION
After the first patching time, if you delete `PrevoiusOutput.txt` and run the patching a second time, an error exception will occur: `System.IO.DirectoryNotFoundException: "Could not find a part of the path 'C:\Pandora Output\Pandora_Engine\PreviousOutput.txt '."`