### PR TITLE
[Fix]: Use InvariantCulture for default thread culture

### DIFF
--- a/Pandora Behaviour Engine/App.axaml.cs
+++ b/Pandora Behaviour Engine/App.axaml.cs
@@ -45,11 +45,9 @@ public partial class App : Application
 	}
 	private static void SetupCultureInfo()
 	{
-		CultureInfo culture = CultureInfo.CreateSpecificCulture("en-US");
-
-		CultureInfo.DefaultThreadCurrentCulture = culture;
-		CultureInfo.DefaultThreadCurrentUICulture = culture;
-		CultureInfo.CurrentCulture = culture;
+		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+		CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture("en-US");
+		CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 	}
 	private static void SetupAppTheme()
 	{


### PR DESCRIPTION
This PR corrects the parsing of numbers in the wrong format. `CultureInfo.InvariantCulture` is installed for parsing numeric formats regardless of the user's local OS settings. 

Previously, a unified `en-US` culture was established, but this solution did not fix the problem properly, it was only a partial solution.