### PR TITLE
[Fix]: Allow game data directory to be same as assembly directory

### DIFF
--- a/Pandora Behaviour Engine/Paths/ApplicationPaths.cs
+++ b/Pandora Behaviour Engine/Paths/ApplicationPaths.cs
@@ -16,9 +16,10 @@ public sealed class ApplicationPaths : IApplicationPaths
 
 	public FileInfo PathConfig => _pathConfig.Value;
 	private readonly Lazy<FileInfo> _pathConfig;
+	private readonly Lazy<DirectoryInfo> _assemblyDirectory;
 
 	public DirectoryInfo AppDataDirectory => new(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) / "Pandora Behaviour Engine");
-	public DirectoryInfo AssemblyDirectory => new(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName!)!);
+	public DirectoryInfo AssemblyDirectory => _assemblyDirectory.Value;
 	public DirectoryInfo EngineDirectory => new(AssemblyDirectory.FullName / PANDORA_ENGINE_FOLDERNAME);
 	public DirectoryInfo TemplateDirectory => new(EngineDirectory.FullName / "Skyrim" / "Template");
 
@@ -28,5 +29,8 @@ public sealed class ApplicationPaths : IApplicationPaths
 			AppDataDirectory.Create();
 
 		_pathConfig = new Lazy<FileInfo>(() => new FileInfo(AppDataDirectory.FullName / CONFIG_FILE));
+#pragma warning disable CA1839 // Use 'Environment.ProcessPath' in USVFS, this would return the virtualized path, while we want the real path.
+		_assemblyDirectory = new Lazy<DirectoryInfo>(() => new DirectoryInfo(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName)!));
+#pragma warning restore CA1839 // Use 'Environment.ProcessPath'
 	}
 }

--- a/Pandora Behaviour Engine/Settings/SubSettings/PathSettings.cs
+++ b/Pandora Behaviour Engine/Settings/SubSettings/PathSettings.cs
@@ -32,9 +32,7 @@ internal sealed class PathSettings(
 	public DirectoryInfo GameData => userPaths.GameData;
 	public DirectoryInfo Output => userPaths.Output;
 
-	public bool IsGameDataValid =>
-		!GameData.FullName.Equals(appPaths.AssemblyDirectory.FullName, StringComparison.OrdinalIgnoreCase)
-		&& validator.IsValid(GameData);
+	public bool IsGameDataValid => validator.IsValid(GameData);
 
 	public bool NeedsUserSelection => !IsGameDataValid;
 


### PR DESCRIPTION
This should be the actual fix for #604. For some reason, the game data path wasn't considered valid if it's in the same directory as `Pandora Behaviour Engine+.exe`.