### PR TITLE
[Feat]: Store Settings.json in installation folder to support different settings per MO2 profile

### DIFF
--- a/Pandora Behaviour Engine/Paths/Abstractions/IApplicationPaths.cs
+++ b/Pandora Behaviour Engine/Paths/Abstractions/IApplicationPaths.cs
@@ -21,5 +21,5 @@ public interface IApplicationPaths
 	DirectoryInfo AssemblyDirectory { get; }
 	DirectoryInfo TemplateDirectory { get; }
 	DirectoryInfo EngineDirectory { get; }
-	FileInfo PathConfig { get; }
+	FileInfo ConfigFile { get; }
 }

--- a/Pandora Behaviour Engine/Paths/Abstractions/IEnginePathsFacade.cs
+++ b/Pandora Behaviour Engine/Paths/Abstractions/IEnginePathsFacade.cs
@@ -19,5 +19,5 @@ public interface IEnginePathsFacade
 
 	FileInfo OutputPreviousFile { get; }
 	FileInfo ActiveModsFile { get; }
-	FileInfo PathConfig { get; }
+	FileInfo ConfigFile { get; }
 }

--- a/Pandora Behaviour Engine/Paths/ApplicationPaths.cs
+++ b/Pandora Behaviour Engine/Paths/ApplicationPaths.cs
@@ -1,47 +1,50 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2023-2026 Pandora Behaviour Engine Contributors
 
+using Pandora.Paths.Abstractions;
+using Pandora.Paths.Extensions;
 using System;
 using System.Diagnostics;
 using System.IO;
-using Pandora.Paths.Abstractions;
-using Pandora.Paths.Extensions;
 
 namespace Pandora.Paths;
 
 public sealed class ApplicationPaths : IApplicationPaths
 {
 	private const string PANDORA_ENGINE_FOLDERNAME = "Pandora_Engine";
-	private const string CONFIG_FILE = "Settings.json";
+	private const string CONFIG_FILENAME = "Settings.json";
 
-	public FileInfo PathConfig => _pathConfig.Value;
-	private readonly Lazy<FileInfo> _pathConfig;
-	private readonly Lazy<DirectoryInfo> _assemblyDirectory;
+	// Will be virtualized by MO2 to support different settings for different profiles
+	public FileInfo ConfigFile { get; } = new FileInfo(Path.GetDirectoryName(Environment.ProcessPath)! / CONFIG_FILENAME);
 
-	public DirectoryInfo AppDataDirectory =>
-		new(
-			Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
-				/ "Pandora Behaviour Engine"
-		);
-	public DirectoryInfo AssemblyDirectory => _assemblyDirectory.Value;
-	public DirectoryInfo EngineDirectory =>
-		new(AssemblyDirectory.FullName / PANDORA_ENGINE_FOLDERNAME);
-	public DirectoryInfo TemplateDirectory => new(EngineDirectory.FullName / "Skyrim" / "Template");
+	public DirectoryInfo AppDataDirectory { get; } =
+		new(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) / "Pandora Behaviour Engine");
+
+#pragma warning disable CA1839 // Use 'Environment.ProcessPath' in USVFS, this would return the virtualized path, while we want the real path.
+	public DirectoryInfo AssemblyDirectory { get; } = new DirectoryInfo(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName)!);
+#pragma warning restore CA1839 // Use 'Environment.ProcessPath'
+
+	public DirectoryInfo EngineDirectory { get; }
+	public DirectoryInfo TemplateDirectory { get; }
 
 	public ApplicationPaths()
 	{
 		if (!AppDataDirectory.Exists)
 			AppDataDirectory.Create();
 
-		_pathConfig = new Lazy<FileInfo>(() =>
-			new FileInfo(AppDataDirectory.FullName / CONFIG_FILE)
-		);
-#pragma warning disable CA1839 // Use 'Environment.ProcessPath' in USVFS, this would return the virtualized path, while we want the real path.
-		_assemblyDirectory = new Lazy<DirectoryInfo>(() =>
-			new DirectoryInfo(
-				Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName)!
-			)
-		);
-#pragma warning restore CA1839 // Use 'Environment.ProcessPath'
+		if (!ConfigFile.Exists)
+		{
+			// Migrate config from old location (before MO2 multi-profile support) if it exists
+			var oldConfigPath = Path.Join(AppDataDirectory.FullName, CONFIG_FILENAME);
+			if (File.Exists(oldConfigPath))
+			{
+				File.Copy(oldConfigPath, ConfigFile.FullName);
+				// Refresh so ConfigFile.Exists will return true now
+				ConfigFile.Refresh();
+			}
+		}
+
+		EngineDirectory = new(AssemblyDirectory.FullName / PANDORA_ENGINE_FOLDERNAME);
+		TemplateDirectory = new(EngineDirectory.FullName / "Skyrim" / "Template");
 	}
 }

--- a/Pandora Behaviour Engine/Paths/EnginePathsFacade.cs
+++ b/Pandora Behaviour Engine/Paths/EnginePathsFacade.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2023-2026 Pandora Behaviour Engine Contributors
 
-using System.IO;
 using Pandora.Paths.Abstractions;
+using System.IO;
 
 namespace Pandora.Paths;
 
@@ -19,7 +19,7 @@ public sealed class EnginePathsFacade(
 	public DirectoryInfo TemplateFolder => appPaths.TemplateDirectory;
 	public DirectoryInfo EngineFolder => appPaths.EngineDirectory;
 
-	public FileInfo PathConfig => appPaths.PathConfig;
+	public FileInfo ConfigFile => appPaths.ConfigFile;
 
 	public DirectoryInfo OutputEngineFolder => outputPaths.PandoraEngineDirectory;
 	public DirectoryInfo OutputMeshesFolder => outputPaths.MeshesDirectory;

--- a/Pandora Behaviour Engine/Paths/Extensions/PathExtensions.cs
+++ b/Pandora Behaviour Engine/Paths/Extensions/PathExtensions.cs
@@ -9,6 +9,6 @@ public static class PathExtensions
 {
 	extension(string)
 	{
-		public static string operator /(string left, string right) => Path.Combine(left, right);
+		public static string operator /(string left, string right) => Path.Join(left, right);
 	}
 }

--- a/Pandora Behaviour Engine/Settings/SettingsRepository.cs
+++ b/Pandora Behaviour Engine/Settings/SettingsRepository.cs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2023-2026 Pandora Behaviour Engine Contributors
 
+using Pandora.Paths.Abstractions;
+using Pandora.Settings.DTOs;
 using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Pandora.Paths.Abstractions;
-using Pandora.Settings.DTOs;
 
 namespace Pandora.Settings;
 
@@ -19,7 +19,7 @@ public partial class PandoraJsonContext : JsonSerializerContext;
 
 public sealed class SettingsRepository(IApplicationPaths appPaths) : ISettingsRepository
 {
-	private readonly FileInfo _configFile = appPaths.PathConfig;
+	private readonly FileInfo _configFile = appPaths.ConfigFile;
 
 	public RootConfiguration Load()
 	{
@@ -43,9 +43,6 @@ public sealed class SettingsRepository(IApplicationPaths appPaths) : ISettingsRe
 
 	public void Save(RootConfiguration data)
 	{
-		if (!_configFile.Directory!.Exists)
-			_configFile.Directory.Create();
-
 		using var stream = _configFile.Create();
 		JsonSerializer.Serialize(stream, data, PandoraJsonContext.Default.RootConfiguration);
 	}

--- a/Pandora Tests/Unit/EndToEndTests.cs
+++ b/Pandora Tests/Unit/EndToEndTests.cs
@@ -24,8 +24,8 @@ public sealed class DependencyInjectedCluster : IDisposable
 		var root = new DirectoryInfo(Environment.CurrentDirectory);
 		root.Create();
 
-		var gameDataDir = new DirectoryInfo(Path.Combine(root.FullName, "Data"));
-		var outputDir = new DirectoryInfo(Path.Combine(root.FullName, "Output"));
+		var gameDataDir = new DirectoryInfo(Path.Join(root.FullName, "Data"));
+		var outputDir = new DirectoryInfo(Path.Join(root.FullName, "Output"));
 
 		gameDataDir.Create();
 		outputDir.Create();
@@ -34,8 +34,7 @@ public sealed class DependencyInjectedCluster : IDisposable
 		var meshesDir = outputDir.CreateSubdirectory("meshes");
 
 		var appEngineDir = root.CreateSubdirectory("Pandora_Engine");
-		var templateDir = appEngineDir.CreateSubdirectory(Path.Combine("Skyrim", "Template"));
-
+		var templateDir = appEngineDir.CreateSubdirectory(Path.Join("Skyrim", "Template"));
 		var userPathsSub = Substitute.For<IUserPaths>();
 
 		userPathsSub.Output.Returns(outputDir);
@@ -49,8 +48,8 @@ public sealed class DependencyInjectedCluster : IDisposable
 		appPathsSub.AssemblyDirectory.Returns(assemblyDir);
 		appPathsSub.EngineDirectory.Returns(appEngineDir);
 		appPathsSub.TemplateDirectory.Returns(templateDir);
-		appPathsSub.PathConfig.Returns(
-			new FileInfo(Path.Combine(appEngineDir.FullName, "Paths.json"))
+		appPathsSub.ConfigFile.Returns(
+			new FileInfo(Path.Join(assemblyDir.FullName, "Settings.json"))
 		);
 
 		services.AddSingleton(appPathsSub);
@@ -60,10 +59,10 @@ public sealed class DependencyInjectedCluster : IDisposable
 		outputPathsSub.PandoraEngineDirectory.Returns(pandoraEngineDir);
 		outputPathsSub.MeshesDirectory.Returns(meshesDir);
 		outputPathsSub.PreviousOutputFile.Returns(
-			new FileInfo(Path.Combine(pandoraEngineDir.FullName, "PreviousOutput.txt"))
+			new FileInfo(Path.Join(pandoraEngineDir.FullName, "PreviousOutput.txt"))
 		);
 		outputPathsSub.ActiveModsFile.Returns(
-			new FileInfo(Path.Combine(pandoraEngineDir.FullName, "ActiveMods.json"))
+			new FileInfo(Path.Join(pandoraEngineDir.FullName, "ActiveMods.json"))
 		);
 
 		services.AddSingleton(outputPathsSub);


### PR DESCRIPTION
This PR changes the location of the settings file to the (virtualized) installation folder of Pandora (the same folder as the executable). The old settings file will be migrated to the new location if found. It also includes some refactoring (renaming some properties, using the more performant `Path.Join` instead of `Path.Combine`, and removing some unnecessary complexity in the `ApplicationPaths` class. I also updated the `EndToEndTests` to use the new location.

The .NET Format workflow will fail because some other files on the preview branch weren't formatted, but I made sure to run `dotnet format` for the files I changed in this PR. The other ones should be taken care of in my other PR (#629).